### PR TITLE
Adding Data Containers for all services: volumes -> volumes_from

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,36 @@
+# Data Containers
+
+couchdbData:
+  image: busybox
+  volumes:
+    - /usr/local/lib/npmo/couchdb:/usr/local/var/lib/couchdb
+
+elasticsearchData:
+  image: busybox
+  volumes:
+    - /usr/local/lib/npmo/elasticsearch:/data
+
+postgresData:
+  image: busybox
+  volumes:
+    - /usr/local/lib/npmo/postgresql:/var/lib/postgresql/data
+
+authData:
+  image: busybox
+  volumes:
+    - /usr/local/lib/npmo/data:/etc/npme/data
+
+packagesData:
+  image: busybox
+  volumes:
+    - /usr/local/lib/npmo/packages:/etc/npme/packages
+
 # couchdb
 
 couchdbprimary:
   build: roles/couchdb
-  volumes:
-    - /usr/local/lib/npmo/couchdb:/usr/local/var/lib/couchdb
+  volumes_from:
+    - "couchdbData"
   ports:
     - "55984:5984"
 
@@ -26,8 +53,8 @@ auth:
   links:
     - redis
   restart: always
-  volumes:
-    - /usr/local/lib/npmo/data:/etc/npme/data
+  volumes_from:
+    - "authData"
   env_file: .env
 
 frontdoor:
@@ -58,18 +85,17 @@ frontdoor:
   ports:
     - "8080:8080"
   restart: always
-  volumes:
-    - /usr/local/lib/npmo/data:/etc/npme/data
-    - /usr/local/lib/npmo/packages:/etc/npme/packages
-  env_file: .env
+  volumes_from:
+    - "authData"
+    - "packagesData"
 
 nginx:
   image: bcoe/nginx:1.0.0
   expose:
     - "8000"
   restart: always
-  volumes: # TODO use volumes_from?
-    - /usr/local/lib/npmo/packages:/etc/npme/packages
+  volumes_from:
+    - "packagesData"
 
 redis:
   expose:
@@ -88,8 +114,8 @@ validate:
   links:
     - couchdbprimary
   restart: always
-  volumes: # TODO use volumes_from?
-    - /usr/local/lib/npmo/packages:/etc/npme/packages
+  volumes_from:
+    - "packagesData"
   env_file: .env
 
 # website
@@ -99,8 +125,8 @@ postgres:
     - "5432"
   image: bcoe/postgres:9.3
   restart: always
-  volumes:
-    - /usr/local/lib/npmo/postgresql:/var/lib/postgresql/data
+  volumes_from:
+    - "postgresData"
 
 rrfollower:
   build: roles/rr-follower
@@ -108,8 +134,8 @@ rrfollower:
   links:
     - postgres
     - couchdbprimary
-  volumes:
-    - /usr/local/lib/npmo/data:/etc/npme/data
+  volumes_from:
+    - "authData"
   env_file: .env
 
 rrservice:
@@ -139,8 +165,8 @@ elasticsearch:
   restart: always
   expose:
     - "9200"
-  volumes:
-    - /usr/local/lib/npmo/elasticsearch:/data
+  volumes_from:
+    - "elasticsearchData"
 
 esfollower:
   image: bcoe/es-follower:1.0.3
@@ -168,8 +194,8 @@ policyfollower:
     - WHITELIST_PATH=/etc/npme/data/whitelist
     - SHARED_FETCH_SECRET=false
     - SEND_SHARED_FETCH_SECRET=
-  volumes:
-    - /usr/local/lib/npmo/data:/etc/npme/data
+  volumes_from:
+    - "authData"
   env_file: .env
 
 # tools
@@ -180,6 +206,6 @@ tools:
   links:
     - couchdbprimary
     - nginx
-  volumes:
-    - /usr/local/lib/npmo/data:/etc/npme/data
-    - /usr/local/lib/npmo/packages:/etc/npme/packages
+  volumes_from:
+    - "authData"
+    - "packagesData"


### PR DESCRIPTION
# Data Containers

Useful for making backups of all the services.
- Reuses volume concepts
- Replaces repeated `volume` entries with each `volumes_from`.
# Developing

Use the same command for compose to rebuild. It will rebuild the data containers automatically.

``` sh
[root@pppdc9prda2x tools]# docker-compose up
Going to remove npmodockercompose_couchdbData_1, npmodockercompose_postgresData_1, npmodockercompose_packagesData_1, npmodockercompose_authData_1, npmodockercompose_elasticsearchData_1
Are you sure? [yN] y
Removing npmodockercompose_couchdbData_1 ... done
Removing npmodockercompose_postgresData_1 ... done
Removing npmodockercompose_packagesData_1 ... done
Removing npmodockercompose_authData_1 ... done
Removing npmodockercompose_elasticsearchData_1 ... done
Creating npmodockercompose_elasticsearchData_1
Creating npmodockercompose_authData_1
npmodockercompose_redis_1 is up-to-date
Recreating npmodockercompose_auth_1
Creating npmodockercompose_packagesData_1
Recreating npmodockercompose_nginx_1
Recreating npmodockercompose_elasticsearch_1
Creating npmodockercompose_postgresData_1
Recreating npmodockercompose_postgres_1
Recreating npmodockercompose_rrservice_1
Recreating npmodockercompose_newww_1
Creating npmodockercompose_couchdbData_1
Recreating npmodockercompose_couchdbprimary_1
Recreating npmodockercompose_validate_1
Recreating npmodockercompose_rrfollower_1
```
