### PR TITLE
Adding Docker-only installation in addition to nodejs/npm license setup

### DIFF
--- a/Dockerfile.configure
+++ b/Dockerfile.configure
@@ -1,0 +1,3 @@
+FROM node:4-onbuild
+
+CMD npm run configure

--- a/README.md
+++ b/README.md
@@ -8,18 +8,94 @@ A docker setup for npmo, split into three main components:
 
 **Note:** Only works locally, very WIP.
 
-## Running
 
-Install the [Docker Toolbox][docker-toolbox], create a machine and run:
+# Requirements
 
-```
+* Install the [Docker Toolbox][docker-toolbox], create a machine.
+* Make sure you have the latest version of the `docker engine` and `docker compose`.
+* Optional Node.js/NPM install
+
+# License Setup
+
+## Install with Node.js/NPM
+
+If you have node.js installed in your environment, then you can setup as follows:
+
+```sh
+$ npm install
 $ npm run configure
 ```
 
-This will download your license, and create a docker-compose.yml file. Followed by:
+## Install with Docker
+
+* Direct Internet access
+
+If your host has access to the internet and registry.npmjs.com.
 
 ```
-$ npm run up
+$ docker build -t configure -f ./Dockerfile.configure .
+```
+
+* Behind the HTTP_PROXY
+
+```
+$ docker build --build-arg HTTP_PROXY=$HTTP_PROXY -t licensesetup -f ./Dockerfile.configure .
+```
+
+## Run Configuration
+
+```
+$ docker run --name license_verify -ti --rm -e HTTP_PROXY=$HTTP_PROXY licensesetup bash
+root@050a2795bc15:/usr/src/app#
+```
+
+At this point, you are placed at the container terminal where you can run `npm run configure` to setup the license.
+
+```sh
+root@050a2795bc15:/usr/src/app# npm run configure
+npm info it worked if it ends with ok
+npm info using npm@2.14.7
+npm info using node@v4.2.2
+npm info preconfigure npmo-docker@1.0.0
+npm info configure npmo-docker@1.0.0
+
+> npmo-docker@1.0.0 configure /usr/src/app
+> ./bin/npme-docker-compose.js configure
+
+? enter your billing email TYPE_YOUR_EMAIL
+? enter your license key PASTE_YOUR_LICENSE
+? the full front-facing URL of your registry REGISTRY_URL
+? proxy URL for outbound requests (optional) HTTP_PROXY
+\o/ you can now go ahead and run `npm run up`
+npm info postconfigure npmo-docker@1.0.0
+npm info ok
+```
+
+After you finish, you can detach from the container pressing CTRL+P and CTRL+Q.
+
+## Copy License
+
+You confirm and copy the license.
+
+```sh
+$ docker diff license_verify
+C /usr
+C /usr/src
+C /usr/src/app
+C /usr/src/app/roles
+C /usr/src/app/roles/registry
+C /usr/src/app/roles/registry/files
+A /usr/src/app/roles/registry/files/.license.json
+A /usr/src/app/.env
+D /usr/src/app/npm-debug.log
+
+$ docker cp license_verify:/usr/src/app/roles/registry/files/.license.json roles/registry/files/
+```
+
+This will copy the license to the appropriate directory. You can now run the services!
+
+```
+$ docker-compose up
 ```
 
 This will start the docker instances.


### PR DESCRIPTION
This commit add instructions and the Dockerfile.configure to setup
the license using Docker itself. This is intended to be run manually for those who does not have Node.js installed in the hosts.

 1 build configure

``` sh
docker build --build-arg HTTP_PROXY=$HTTP_PROXY -t configure -f ./Dockerfile.configure .
Sending build context to Docker daemon 158.7 kB
Step 1 : FROM node:4-onbuild
# Executing 3 build triggers...
Step 1 : COPY package.json /usr/src/app/
 ---> Using cache
Step 1 : RUN npm install
 ---> Using cache
Step 1 : COPY . /usr/src/app
 ---> f56332956c54
Removing intermediate container a9effab98f22
Step 2 : CMD npm run configure
 ---> Running in 7089ecb22f41
 ---> d97cf4e9439e
Removing intermediate container 7089ecb22f41
Successfully built d97cf4e9439e
```

 2 run configure

``` sh
[root@pppdc9prda2x npmo-docker-compose]# docker run -ti --name configure -e HTTP_PROXY=$HTTP_PROXY configure bash
root@050a2795bc15:/usr/src/app# npm run configure
npm info it worked if it ends with ok
npm info using npm@2.14.7
npm info using node@v4.2.2
npm info preconfigure npmo-docker@1.0.0
npm info configure npmo-docker@1.0.0

> npmo-docker@1.0.0 configure /usr/src/app
> ./bin/npme-docker-compose.js configure

? enter your billing email marcello_desales@company.com
? enter your license key 1af3df63-44004040400404040400404
? the full front-facing URL of your registry http://registry.company.com
? proxy URL for outbound requests (optional) http://qypprdproxy02.ie.proxy.net:80
\o/ you can now go ahead and run `npm run up`
npm info postconfigure npmo-docker@1.0.0
npm info ok
```

At this point, you can just hit CTRL+P then CTRL+Q to detach from the container.

 3 View diff

``` sh
$ docker diff configure
C /usr
C /usr/src
C /usr/src/app
C /usr/src/app/roles
C /usr/src/app/roles/registry
C /usr/src/app/roles/registry/files
A /usr/src/app/roles/registry/files/.license.json
A /usr/src/app/.env
D /usr/src/app/npm-debug.log
```

 4 Copy license

``` sh
$ docker cp 050a2795bc15:/usr/src/app/roles/registry/files/.license.json roles/registry/files/
```
