### PR TITLE
Add conf.d config of couchdb

### DIFF
--- a/roles/confd/Dockerfile
+++ b/roles/confd/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.4
+
+RUN apk update && \
+    apk upgrade && \
+    apk add ca-certificates curl && \
+    rm -rf /var/cache/apk/*
+
+ENV CONFD_VERSION=0.12.0-alpha3
+
+RUN curl -L -o /bin/confd \
+    "https://github.com/kelseyhightower/confd/releases/download/v$CONFD_VERSION/confd-$CONFD_VERSION-linux-amd64" && \
+    chmod +x /bin/confd
+
+ENTRYPOINT ["/bin/confd"]
+CMD ["-onetime", "-backend", "env"]

--- a/roles/couchdb-config/Dockerfile
+++ b/roles/couchdb-config/Dockerfile
@@ -1,0 +1,7 @@
+FROM bcoe/confd
+
+ADD npm.toml /etc/confd/conf.d/
+ADD npm.ini.tmpl /etc/confd/templates/
+
+RUN mkdir -p /usr/local/etc/couchdb/local.d
+VOLUME /usr/local/etc/couchdb/local.d

--- a/roles/couchdb-config/npm.ini.tmpl
+++ b/roles/couchdb-config/npm.ini.tmpl
@@ -1,0 +1,37 @@
+; CouchDB Configuration Settings
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[couchdb]
+delayed_commits = false
+
+[httpd]
+secure_rewrites = false
+
+[couch_httpd_auth]
+public_fields = appdotnet, avatar, avatarMedium, avatarLarge, date, email, fields, freenode, fullname, github, homepage, name, roles, twitter, type, _id, _rev
+users_db_public = true
+
+[log]
+level = info
+
+; To enable Virtual Hosts in CouchDB, add a vhost = path directive. All requests to
+; the Virual Host will be redirected to the path. In the example below all requests
+; to http://example.com/ are redirected to /database.
+; If you run CouchDB on a specific port, include the port number in the vhost:
+; example.com:5984 = /database
+[vhosts]
+registry.npmjs.org = /registry/_design/app/_rewrite
+
+[update_notification]
+;unique notifier name=/full/path/to/exe -with "cmd line arg"
+
+; To create an admin account uncomment the '[admins]' section below and add a
+; line in the format 'username = password'. When you next start CouchDB, it
+; will change the password to a hash (so that your passwords don't linger
+; around in plain-text files). You can add more admin accounts with more
+; 'username = password' lines. Don't forget to restart CouchDB after
+; changing this.
+[admins]
+{{getv "/couchdb/user"}} = {{getv "/couchdb/password"}}

--- a/roles/couchdb-config/npm.toml
+++ b/roles/couchdb-config/npm.toml
@@ -1,0 +1,7 @@
+[template]
+src = "npm.ini.tmpl"
+dest = "/usr/local/etc/couchdb/local.d/npm.ini"
+keys = [
+  "/couchdb/user",
+  "/couchdb/password",
+]


### PR DESCRIPTION
This pull request adds [conf.d](https://github.com/kelseyhightower/confd) as a way to generate config files when using docker-compose. Couchdb requires the use of config files so conf.d is used to generate the config file off of a template.

Confd supports multiple backends such as [Vault[(https://www.vaultproject.io/) and Rancher Metadata, but in this case environment variables are used. The `CMD` section can be modified to try the different backends.

An example docker-compose.yml with the `${FOO}` values specified in an .env file in the root directory would be as follows.

```
couchdbprimary:
 image: couchdb:1
 container_name: couchdbprimary
 environment:
   COUCHDB_USER: ${COUCHDB_USER}
   COUCHDB_PASSWORD: ${COUCHDB_PASSWORD}
 volumes:
   - ${HOST_VOLUME}/couchdb:/usr/local/var/lib/couchdb
 volumes_from:
   - couchdb-config
 volume_driver: local
 labels:
   io.rancher.container.pull_image: always
   io.rancher.sidekicks: couchdb-config

couchdb-config:
 image: bcoe/couchdb-config
 environment:
   COUCHDB_USER: ${COUCHDB_USER}
   COUCHDB_PASSWORD: ${COUCHDB_PASSWORD}
 labels:
   io.rancher.container.pull_image: always
   io.rancher.container.start_once: "true"
```

Some notes
- docker-compose does not like files as volumes so the `/etc/couchdb/local.d` directory is populated rather than the `/etc/couchdb/local.d` file.
- with environment variables `/couchdb/user` is translated to COUCHDB_USER which matches the configuration of `couchdb`.
- the `couchdb-config` container is currently set to run once and then stop. the volume will still be available to the `couchdbprimary` container so this is as expected.
- it might make sense in case anyone ever wants to split anything to have a COUCHDB_HOST or something like that so the couchdb backend can live in its own compose.
